### PR TITLE
Added test for TOC to .travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,12 @@ rvm:
   - 2.2
 before_script:
   - gem install awesome_bot
+  - npm install doctoc
+  - rm -rf node_modules/anchor-markdown-header
+  - git clone --depth=50 https://github.com/thlorenz/anchor-markdown-header node_modules/anchor-markdown-header
 script:
 - awesome_bot README.md --allow-dupe --allow-redirect
 - awesome_bot README_*.md --allow-dupe --allow-redirect
+- node node_modules/doctoc/doctoc.js README.md README_*.md
+- test -z "`git diff -- README.md`"
+- test -z "`git diff -- README_*.md`"


### PR DESCRIPTION
Runs doctoc for README*.md
If in newly doctoc'ed README*.md there are any diffs against
ones commited in git HEAD then the test failes.
The script are using the latest anchor-markdown-header from repo
to avoid the bug with non-ASCII headers.